### PR TITLE
Copy the relevant parts of AsyncFunctionStart into ModuleExecution

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -77,12 +77,30 @@ contributors: Myles Borins
     1. Assert: _module_ has been linked and declarations in its module environment have been instantiated.
     1. Set the VariableEnvironment of _moduleCxt_ to _module_.[[Environment]].
     1. Set the LexicalEnvironment of _moduleCxt_ to _module_.[[Environment]].
-    1. Suspend the currently running execution context.
-    1. Push _moduleCxt_ on to the execution context stack; _moduleCxt_ is now the running execution context.
-    1. Let _result_ be the result of evaluating _module_.[[ECMAScriptCode]].
-    1. Suspend _moduleCxt_ and remove it from the execution context stack.
-    1. Resume the context that is now on the top of the execution context stack as the running execution context.
-    1. Return Completion(_result_).
+    1. <ins>Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).</ins>
+    1. <ins>Let _runningContext_ be the running execution context.</ins>
+    1. Suspend <del>the currently running execution context</del><ins>_runningContext_</ins>. <!-- ??? Why is this here and not an equivalent in AsyncFunctionStart? Oh well. -->
+    1. <ins>Set the code evaluation state of _moduleCxt_ such that when evaluation is resumed for that execution context the following steps will be performed:</ins>
+      1. Let _result_ be the result of evaluating _module_.[[ECMAScriptCode]].
+      1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
+      1. Remove _moduleCxt_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+      1. If _result_.[[Type]] is ~normal~, then
+        1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
+      1. Else if _result_.[[Type]] is ~return~, then
+        1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo;_result_.[[Value]]&raquo;).
+      1. Else,
+        1. Assert: _result_.[[Type]] is ~throw~.
+        1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).
+      1. Return.
+    1. <ins>Push _moduleCxt_ onto the execution context stack; _moduleCxt_ is now the running execution context.</ins>
+    1. <ins>Resume the suspended evaluation of _moduleCxt_. Let _result_ be the value returned by the resumed computation.</ins>
+    1. <ins>Assert: When we return here, _moduleCxt_ has already been removed from the execution context stack and _runningContext_ is the currently running execution context.</ins>
+    1. <ins>Assert: _result_ is a normal completion with a value of *undefined*. The possible sources of completion values are Await or, if the module body doesn't await anything, the step X.g above.</ins>
+    1. <del>Push _moduleCxt_ on to the execution context stack; _moduleCxt_ is now the running execution context.</del>
+    1. <del>Let _result_ be the result of evaluating _module_.[[ECMAScriptCode]].</del>
+    1. <del>Suspend _moduleCxt_ and remove it from the execution context stack.</del>
+    1. Resume <del>the context</del><ins>_runningContext_,</ins> that is now on the top of the execution context stack as the running execution context.
+    1. Return Completion(<del>_result_</del><ins>_promiseCapability_.[[Promise]]</ins>).
   </emu-alg>
 </emu-clause>
 


### PR DESCRIPTION
ModuleExecution now returns a promise derived from evaluating the body kind of as if it were an async function. This duplicates a decent amount of spec from AsyncFunctionStart; we should refactor this next.

Nobody uses this promise return value yet. And, it's not grammatically allowed to use `await` yet. But, this is a start.